### PR TITLE
Setting Parameters For Distributions After Initialization

### DIFF
--- a/ugly/Bernoulli.php
+++ b/ugly/Bernoulli.php
@@ -14,6 +14,17 @@
 
 			$this->fraction = $fraction;
 		}
+		
+		/**
+		 * written by: Waqas Tariq Dar : waqastariqdar@gmail.com , waqas.tariq@lums.edu.pk , waqas.tariq@pucit.edu.pk
+		 * This setter function sets the fraction parameter for calling object
+		 * @param $fraction
+		 */
+
+		public function setFraction($fraction) {
+			self::validateParameters($fraction);
+			$this->fraction = $fraction;
+		}
 
 		public function mean() { return $this->fraction; }
 		public function variance() { return ($this->fraction) * (1-$this->fraction);}

--- a/ugly/Beta.php
+++ b/ugly/Beta.php
@@ -46,6 +46,32 @@
 			$this->beta = $b;
 		}
 		
+		/**
+		 * written by: Waqas Tariq Dar : waqastariqdar@gmail.com , waqas.tariq@lums.edu.pk , waqas.tariq@pucit.edu.pk
+		 * This setter function sets the alpha parameter for calling object
+		 * @param $a
+		 */
+
+		public function setAlpha($a) {
+			if($a <= 0) {
+				throw new InvalidArgumentException("α (\$a = " . var_export($a, true) . ") must be greater than 0. ");
+			}
+			$this->alpha = $a;
+		}
+
+		/**
+		 * written by: Waqas Tariq Dar : waqastariqdar@gmail.com , waqas.tariq@lums.edu.pk , waqas.tariq@pucit.edu.pk
+		 * This setter function sets the beta parameter for calling object
+		 * @param $b
+		 */
+
+		public function setBeta($b) {
+			if($b <= 0) {
+				throw new InvalidArgumentException("β (\$b = " . var_export($b, true) . ") must be greater than 0. ");
+			}
+			$this->beta = $b;
+		}
+		
 		public function icdf($p) {
 			$x = 0;
 			$a = 0;

--- a/ugly/Binomial.php
+++ b/ugly/Binomial.php
@@ -21,6 +21,32 @@ class GBPDP_Binomial extends GBPDP_Distribution {
 		$this->n = $n;
 		$this->p = $p;
 	}
+	
+	/**
+	 * written by: Waqas Tariq Dar : waqastariqdar@gmail.com , waqas.tariq@lums.edu.pk , waqas.tariq@pucit.edu.pk
+	 * This setter function sets the n (number of Observation) parameter for calling object
+	 * @param $n
+	 */
+
+	public function setN($n) {
+		if (!is_int($n) || $n <= 0) {
+			throw new InvalidArgumentException("Parameter (\$n = " . var_export($n, true) . " must be a positive integer. ");
+		}
+		$this->n = $n;
+	}
+
+	/**
+	 * written by: Waqas Tariq Dar : waqastariqdar@gmail.com , waqas.tariq@lums.edu.pk , waqas.tariq@pucit.edu.pk
+	 * This setter function sets the p (probability of success) parameter for calling object
+	 * @param $p
+	 */
+
+	public function setP($p) {
+		if($p < 0 || $p > 1) {
+			throw new InvalidArgumentException("Parameter (\$p = " . var_export($p, true) . " must be between 0 and 1. ");
+		}
+		$this->p = $p;
+	}
 
 	public function mean() { return $this->n * $this->p; }
 	public function variance() { return $this->n * $this->p * (1-$this->p);}

--- a/ugly/Gamma.php
+++ b/ugly/Gamma.php
@@ -23,6 +23,26 @@
 			$this->shape = floatval($shape);
 			$this->rate = floatval($rate);
 		}
+		
+		/**
+		 * written by: Waqas Tariq Dar : waqastariqdar@gmail.com , waqas.tariq@lums.edu.pk , waqas.tariq@pucit.edu.pk
+		 * This setter function sets the shape parameter for calling object
+		 * @param $shape
+		 */
+
+		public function setShape($shape) {
+			$this->shape = floatval($shape);
+		}
+
+		/**
+		 * written by: Waqas Tariq Dar : waqastariqdar@gmail.com , waqas.tariq@lums.edu.pk , waqas.tariq@pucit.edu.pk
+		 * This setter function sets the rate parameter for calling object
+		 * @param $rate
+		 */
+
+		public function setRate($rate) {
+			$this->rate = floatval($rate);
+		}
 		public function rand() {
 			return self::draw($this->shape, $this->rate);
 		}

--- a/ugly/Normal.php
+++ b/ugly/Normal.php
@@ -30,6 +30,25 @@
 			//$this->skewness = floatval($skewness);
 			//$this->kurtosis = floatval($kurtosis);
 		}
+		
+		/**
+		 * written by: Waqas Tariq Dar : waqastariqdar@gmail.com 
+		 * This setter function sets the MEAN for calling object
+		 * @param int $mean
+		 */
+
+		public function setMean($mean = 0) {
+			$this->mean = floatval($mean);
+		}
+
+		/**
+		 * written by: Waqas Tariq Dar : waqastariqdar@gmail.com 
+		 * This setter function sets the variance for calling object
+		 * @param int $variance
+		 */
+		public function setVariance($variance = 1) {
+			$this->variance = floatval($variance);
+		}
 
 		public function rand() {
 			return self::draw($this->mean, $this->variance);

--- a/ugly/Poisson.php
+++ b/ugly/Poisson.php
@@ -32,6 +32,17 @@
 
 			$this->lambda = $lambda;
 		}
+		
+		/**
+		 * written by: Waqas Tariq Dar : waqastariqdar@gmail.com , waqas.tariq@lums.edu.pk , waqas.tariq@pucit.edu.pk
+		 * This setter function sets the lambda parameter for calling object
+		 * @param $lambda
+		 */
+
+		public function setLambda($lambda) {
+			self::validateParameters($lambda);
+			$this->lambda = $lambda;
+		}
 
 		public function mean() { return $this->lambda; }
 		public function variance() { return $this->lambda;}

--- a/ugly/T.php
+++ b/ugly/T.php
@@ -22,6 +22,17 @@
 			$this->degrees = floatval($dof); // float, not integer: http://stats.stackexchange.com/questions/116511/explanation-for-non-integer-degrees-of-freedom-in-t-test-with-unequal-variances
 			// TODO: some overflow problems to be dealt with here (large DOF)
 		}
+		
+		/**
+		 * written by: Waqas Tariq Dar : waqastariqdar@gmail.com , waqas.tariq@lums.edu.pk , waqas.tariq@pucit.edu.pk
+		 * This setter function sets the degrees of freedom parameter for calling object
+		 * @param $dof
+		 */
+
+		public function setDOF($dof) {
+			self::validateParameters($dof);
+			$this->degrees = floatval($dof); 
+		}
 
 		public static function validateParameters($dof) {
 			if(!is_numeric($dof))


### PR DESCRIPTION
I suggest to add setters function for MEAN and VARIANCE. Reason behind this is a need to work with different distribution object in a loop. If we don't have these setters function, then we have to create an object of Normal class in each iteration of loop passing its Mean and Variance in the constructor. Instead, we can create only one object outside the loop and keep setting MEAN and VARIANCE in each iteration for every different distribution.