### PR TITLE
Add license to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
             "email": "joe@truephp.com"
         }
     ],
+    "license": "MIT",
     "autoload": {
         "psr-0": {
             "gburtini\\Distributions":        "src"


### PR DESCRIPTION
The license was missing from the composer.json and the library was showing up as unlicensed in packagist.