### PR TITLE
Fixed PDF formula for the normal distribution

### DIFF
--- a/src/gburtini/Distributions/Normal.php
+++ b/src/gburtini/Distributions/Normal.php
@@ -53,9 +53,10 @@ class Normal extends Distribution
     }
     public function pdf($x)
     {
-        $z = ($x - $this->mean)/$this->variance;
+        $sigma = $this->sd();
+        $z = ($x - $this->mean) / $sigma;
 
-        return exp(-$z*$z/2) / ($this->variance * M_SQRTPI * M_SQRT2);
+        return exp(-$z * $z / 2) / ($sigma * M_SQRTPI * M_SQRT2);
     }
 
     public function cdf($x)

--- a/tests/NormalDistributionTest.php
+++ b/tests/NormalDistributionTest.php
@@ -71,6 +71,15 @@ class NormalDistributionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($d->pdf(-0.5), 0.3520653267, "PDF incorrect", 1e-9);
         $this->assertEquals($d->pdf(1.5), 0.1295175956, "PDF incorrect", 1e-9);
         $this->assertEquals($d->pdf(3.5), 0.0008726826947, "PDF incorrect", 1e-9);
+
+        $d = new Normal(0, 0.2);
+
+        $this->assertEquals(6.4119473711506E-28, $d->pdf(-5), "PDF incorrect", 1e-9);
+        $this->assertEquals(1.460642012962E-7, $d->pdf(-2.5), "PDF incorrect", 1e-9);
+        $this->assertEquals(0.89206205807639, $d->pdf(0), "PDF incorrect", 1e-9);
+        $this->assertEquals(0.47748641153356, $d->pdf(-0.5), "PDF incorrect", 1e-9);
+        $this->assertEquals(0.0032172781336966, $d->pdf(1.5), "PDF incorrect", 1e-9);
+        $this->assertEquals(4.4681378118755E-14, $d->pdf(3.5), "PDF incorrect", 1e-9);
     }
 
     public function testNormalCDF()


### PR DESCRIPTION
Hello! The formula had variance in it instead of standard deviation and thus gave wrong results for non-standard cases (where mean != 0 and sigma != 1).