### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,21 @@
 language: php
 php:
-  - '5.4'
-  - '5.5'
   - '5.6'
   - '7.0'
   - '7.1'
   - '7.2'
+  - '7.3'
   - 'nightly'
+
+matrix:
+  matrix:
+  include:
+    - php: '5.4'
+      dist: 'trusty'
+    - php: '5.5'
+      dist: 'trusty'
+  allow_failures:
+    - php: 'nightly'
 
 script: vendor/bin/phpunit --configuration ./build/travis-ci.xml
 

--- a/build/travis-ci.xml
+++ b/build/travis-ci.xml
@@ -2,7 +2,8 @@
 
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         colors="true">
+         colors="true"
+         bootstrap="../vendor/autoload.php">
   <testsuites>
     <testsuite name="PHP_CodeCoverage">
       <directory suffix="Test.php">../tests</directory>

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,19 @@
   ],
   "license": "MIT",
   "autoload": {
-    "psr-0": {
-      "gburtini\\Distributions": "src"
+    "psr-4": {
+      "gburtini\\Distributions\\": "src/gburtini/Distributions"
     }
   },
-  "require": {},
+  "autoload-dev": {
+    "psr-4": {
+      "gburtini\\Distributions\\Tests\\": "tests"
+    }
+  },
+  "require": {
+    "php": ">=5.4"
+  },
   "require-dev": {
-    "phpunit/phpunit": "^4.8"
+    "phpunit/phpunit": "^4.8.36"
   }
 }

--- a/src/gburtini/Distributions/Binomial.php
+++ b/src/gburtini/Distributions/Binomial.php
@@ -107,37 +107,3 @@ class Binomial extends Distribution
         return $k;
     }
 }
-
-
-class BinomialCI extends Binomial
-{
-    public function jeffreys($confidence = 0.95)
-    {
-        // this is a Bayesian derivation with great frequentist properties, even around 0 and 1 success rates.
-
-        if ($confidence > 1 || $confidence < 0) {
-            throw new \InvalidArgumentException("p-value must be between 0 and 1.");
-        }
-
-        $a = ($this->n * $this->p);
-        $b = ($this->n * (1-$this->p));
-        $beta = new Beta(0.5 + $a, 0.5 + $b);
-
-        if ($a > 0) {
-            $lower = $beta->icdf(1-($confidence));
-        } else {
-            $lower = 0;
-        }
-
-        if ($a < $this->n) {
-            $upper = $beta->icdf(($confidence));
-        } else {
-            $upper = 1;
-        }
-
-        return array(
-            "lower" => $lower,
-            "upper" => $upper
-        );
-    }
-}

--- a/src/gburtini/Distributions/BinomialCI.php
+++ b/src/gburtini/Distributions/BinomialCI.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace gburtini\Distributions;
+
+class BinomialCI extends Binomial
+{
+    public function jeffreys($confidence = 0.95)
+    {
+        // this is a Bayesian derivation with great frequentist properties, even around 0 and 1 success rates.
+
+        if ($confidence > 1 || $confidence < 0) {
+            throw new \InvalidArgumentException("p-value must be between 0 and 1.");
+        }
+
+        $a = ($this->n * $this->p);
+        $b = ($this->n * (1-$this->p));
+        $beta = new Beta(0.5 + $a, 0.5 + $b);
+
+        if ($a > 0) {
+            $lower = $beta->icdf(1-($confidence));
+        } else {
+            $lower = 0;
+        }
+
+        if ($a < $this->n) {
+            $upper = $beta->icdf(($confidence));
+        } else {
+            $upper = 1;
+        }
+
+        return array(
+            "lower" => $lower,
+            "upper" => $upper
+        );
+    }
+}

--- a/tests/BetaDistributionTest.php
+++ b/tests/BetaDistributionTest.php
@@ -1,9 +1,12 @@
 <?php
-require_once dirname(__FILE__) . "/../src/gburtini/Distributions/Beta.php";
+
+namespace gburtini\Distributions\Tests;
 
 use gburtini\Distributions\Beta;
+use PHPUnit\Framework\TestCase;
+use SplFixedArray;
 
-class BetaDistributionTest extends PHPUnit_Framework_TestCase
+class BetaDistributionTest extends TestCase
 {
     public function testBetaInstantiateDistribution()
     {
@@ -37,7 +40,7 @@ class BetaDistributionTest extends PHPUnit_Framework_TestCase
         srand(1); // fix the random key, just for consistency.
 
         $d = new Beta(0.5, 0.5);
-        
+
         $scale = 5000;
         $draws = new SplFixedArray($scale);
         for ($i = 0; $i < $scale; $i++) {
@@ -53,7 +56,7 @@ class BetaDistributionTest extends PHPUnit_Framework_TestCase
         srand(1); // fix the random key, just for consistency.
 
         $d = new Beta(1, 10000);
-        
+
         $scale = 1000;
         $draws = new SplFixedArray($scale);
         for ($i = 0; $i < $scale; $i++) {

--- a/tests/BetaFunctionTest.php
+++ b/tests/BetaFunctionTest.php
@@ -1,7 +1,11 @@
 <?php
-use gburtini\Distributions\Accessories\BetaFunction;
 
-class BetaFunctionTest extends PHPUnit_Framework_TestCase
+namespace gburtini\Distributions\Tests;
+
+use gburtini\Distributions\Accessories\BetaFunction;
+use PHPUnit\Framework\TestCase;
+
+class BetaFunctionTest extends TestCase
 {
     public function testBetaFunction()
     {

--- a/tests/BinomialCITest.php
+++ b/tests/BinomialCITest.php
@@ -1,9 +1,11 @@
 <?php
-require_once dirname(__FILE__) . "/../src/gburtini/Distributions/Binomial.php";
+
+namespace gburtini\Distributions\Tests;
 
 use gburtini\Distributions\BinomialCI;
+use PHPUnit\Framework\TestCase;
 
-class BinomialCITest extends PHPUnit_Framework_TestCase
+class BinomialCITest extends TestCase
 {
     public function testBinomialInstantiateDistribution()
     {

--- a/tests/BinomialDistributionTest.php
+++ b/tests/BinomialDistributionTest.php
@@ -1,77 +1,82 @@
 <?php
-use gburtini\Distributions\Binomial;
 
-class BinomialDistributionTest extends PHPUnit_Framework_TestCase
+namespace gburtini\Distributions\Tests;
+
+use gburtini\Distributions\Binomial;
+use PHPUnit\Framework\TestCase;
+use SplFixedArray;
+
+class BinomialDistributionTest extends TestCase
 {
     public function testBinomialInstantiateDistribution()
     {
         $distribution1 = new Binomial(10, 0.5);
         $distribution1 = new Binomial(6, 0.4);
     }
-    
-    
+
+
     public function testBinomialInvalidInstantiation()
     {
         $this->setExpectedException('InvalidArgumentException');
         $invalid = new Binomial(7.3, 0.5);
     }
-    
+
     public function testBinomialInvalidInstantiation2()
     {
         $this->setExpectedException('InvalidArgumentException');
         $invalid = new Binomial(4, 1.2);
     }
-    
+
     public function testObjectDraw()
     {
         mt_srand(1);
-    
+
         $n = 10;
         $p = 0.3;
-    
+
         $d = new Binomial($n, $p);
-    
+
         $scale = 50000;
         $draws = new SplFixedArray($scale);
         for ($i = 0; $i < $scale; $i++) {
             $draws[$i] = $d->rand();
         }
-    
+
         $number = array_sum((array) $draws) / count($draws);
         $this->assertEquals($n*$p, $number, "Attempting to draw from Binom($n,$p) {$scale} times gives us a value too far from the expected mean. This could be just random chance.", 0.01);
     }
-    
+
     public function testClassDraw()
     {
         mt_srand(1);
-            
+
         $n = 10;
         $p = 0.3;
-            
+
         $scale = 50000;
         $draws = new SplFixedArray($scale);
         for ($i = 0; $i < $scale; $i++) {
             $draws[$i] = Binomial::draw($n, $p);
         }
-            
+
         $number = array_sum((array) $draws) / count($draws);
         $this->assertEquals($n*$p, $number, "Attempting to draw from Binom($n,$p) {$scale} times gives us a value too far from the expected mean. This could be just random chance.", 0.01);
     }
-        
+
     public function testBinomialPDF()
     {
         $d = new Binomial(14, 0.25);
-            
+
         $this->assertEquals($d->pdf(0), 0.01781794801, "PDF incorrect", 1e-9);
         $this->assertEquals($d->pdf(1), 0.08315042407, "PDF incorrect", 1e-9);
         $this->assertEquals($d->pdf(5), 0.1467964277, "PDF incorrect", 1e-9);
         $this->assertEquals($d->pdf(9), 0.001812301576, "PDF incorrect", 1e-9);
     }
-        
+
     public function testBinomialCDF()
     {
         $d = new Binomial(14, 0.25);
-            
+
         $this->assertEquals($d->cdf(0), 0.01781794801, "CDF incorrect", 1e-9);
         $this->assertEquals($d->cdf(1), 0.1009683721, "CDF incorrect", 1e-9);
         $this->assertEquals($d->cdf(2), 0.2811276242, "CDF incorrect", 1e-9);
@@ -79,11 +84,11 @@ class BinomialDistributionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($d->cdf(6), 0.9617292434, "CDF incorrect", 1e-9);
         $this->assertEquals($d->cdf(10), 0.9999601766, "CDF incorrect", 1e-9);
     }
-        
+
     public function testBinomialICDF()
     {
         $d = new Binomial(50, 0.4);
-            
+
         $this->assertEquals($d->icdf(0), 0, "Inverse CDF incorrect");
         $this->assertEquals($d->icdf(0.1), 16, "Inverse CDF incorrect");
         $this->assertEquals($d->icdf(0.3), 18, "Inverse CDF incorrect");

--- a/tests/GammaFunctionTest.php
+++ b/tests/GammaFunctionTest.php
@@ -1,7 +1,11 @@
 <?php
-use gburtini\Distributions\Accessories\GammaFunction;
 
-class GammaFunctionTest extends PHPUnit_Framework_TestCase
+namespace gburtini\Distributions\Tests;
+
+use gburtini\Distributions\Accessories\GammaFunction;
+use PHPUnit\Framework\TestCase;
+
+class GammaFunctionTest extends TestCase
 {
     // NOTE: this uses the log stirling/lanczos implementations depending on whether $a is above 171 or not (accuracy threshold)
     public function testLogGammaFunction()

--- a/tests/IncompleteGammaFunctionTest.php
+++ b/tests/IncompleteGammaFunctionTest.php
@@ -1,7 +1,11 @@
 <?php
-use gburtini\Distributions\Accessories\IncompleteGammaFunction;
 
-class IncompleteGammaFunctionTest extends PHPUnit_Framework_TestCase
+namespace gburtini\Distributions\Tests;
+
+use gburtini\Distributions\Accessories\IncompleteGammaFunction;
+use PHPUnit\Framework\TestCase;
+
+class IncompleteGammaFunctionTest extends TestCase
 {
     public function testIncompleteGammaFunction()
     {

--- a/tests/NormalDistributionTest.php
+++ b/tests/NormalDistributionTest.php
@@ -1,7 +1,12 @@
 <?php
-use gburtini\Distributions\Normal;
 
-class NormalDistributionTest extends PHPUnit_Framework_TestCase
+namespace gburtini\Distributions\Tests;
+
+use gburtini\Distributions\Normal;
+use PHPUnit\Framework\TestCase;
+use SplFixedArray;
+
+class NormalDistributionTest extends TestCase
 {
     public function testNormalInstantiateDistribution()
     {

--- a/tests/PoissonDistributionTest.php
+++ b/tests/PoissonDistributionTest.php
@@ -1,7 +1,12 @@
 <?php
-use gburtini\Distributions\Poisson;
 
-class PoissonDistributionTest extends PHPUnit_Framework_TestCase
+namespace gburtini\Distributions\Tests;
+
+use gburtini\Distributions\Poisson;
+use PHPUnit\Framework\TestCase;
+use SplFixedArray;
+
+class PoissonDistributionTest extends TestCase
 {
     public function testPoissonInstantiateDistribution()
     {
@@ -46,18 +51,18 @@ class PoissonDistributionTest extends PHPUnit_Framework_TestCase
     public function testPoissonPDF()
     {
         $d = new Poisson(2.5);
-    
+
         $this->assertEquals(0.08208499862, $d->pdf(0), 1e-9);
         $this->assertEquals(0.2052124966, $d->pdf(1), 1e-9);
         $this->assertEquals(0.2565156207, $d->pdf(2), 1e-9);
         $this->assertEquals(0.2137630172, $d->pdf(3), 1e-9);
         $this->assertEquals(0.00001021426063, $d->pdf(12), 1e-12);
     }
-    
+
     public function testPoissonCDF()
     {
         $d = new Poisson(2.5);
-    
+
         $this->assertEquals(0.08208499862, $d->cdf(0), 1e-9);
         $this->assertEquals(0.2872974952, $d->cdf(1), 1e-9);
         $this->assertEquals(0.5438131159, $d->cdf(2), 1e-9);
@@ -66,11 +71,11 @@ class PoissonDistributionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(0.9579789618, $d->cdf(5), 1e-9);
         $this->assertEquals(0.9999976158, $d->cdf(12), 1e-9);
     }
-    
+
     public function testPoissonICDF()
     {
         $d = new Poisson(2.5);
-    
+
         $this->assertEquals($d->icdf(0), 0);
         $this->assertEquals($d->icdf(0.082084998), 0);
         $this->assertEquals($d->icdf(0.09), 1);

--- a/tests/TDistributionTest.php
+++ b/tests/TDistributionTest.php
@@ -1,7 +1,11 @@
 <?php
-use gburtini\Distributions\T;
 
-class TDistributionTest extends PHPUnit_Framework_TestCase
+namespace gburtini\Distributions\Tests;
+
+use gburtini\Distributions\T;
+use PHPUnit\Framework\TestCase;
+
+class TDistributionTest extends TestCase
 {
     public function testTInstantiateDistribution()
     {

--- a/tests/WeibullDistributionTest.php
+++ b/tests/WeibullDistributionTest.php
@@ -1,9 +1,12 @@
 <?php
-require_once dirname(__FILE__) . "/../src/gburtini/Distributions/Weibull.php";
+
+namespace gburtini\Distributions\Tests;
 
 use gburtini\Distributions\Weibull;
+use PHPUnit\Framework\TestCase;
+use SplFixedArray;
 
-class WeibullDistributionTest extends PHPUnit_Framework_TestCase
+class WeibullDistributionTest extends TestCase
 {
 	public function testWeibullInstantiateDistribution() {
 		$distribution1 = new Weibull(2.0, 3.1);
@@ -52,7 +55,7 @@ class WeibullDistributionTest extends PHPUnit_Framework_TestCase
 		}
 
 
-		// These perform differently on PHP <= 7.0. I think the RNG changed: As of PHP 7.1.0, rand() uses the same random number generator as mt_rand(). To preserve backwards compatibility rand() allows max to be smaller than min as opposed to returning FALSE as mt_rand(). 
+		// These perform differently on PHP <= 7.0. I think the RNG changed: As of PHP 7.1.0, rand() uses the same random number generator as mt_rand(). To preserve backwards compatibility rand() allows max to be smaller than min as opposed to returning FALSE as mt_rand().
 		$number = array_sum((array) $draws) / count($draws);
 		$mean = $d->mean();
 		$this->assertEquals($number, $mean, "Attempting to draw from Weibull(3.2, 1.4)) {$scale} times gives us a value too far from the expected mean. This could be just random chance.", 0.015);


### PR DESCRIPTION
# Changed log
- Fix Travis CI test
- Let the test classes have the namespace so that it can let this package run unit tests easily.
- Split `BinomialCI` from `Binomial.php` file because it should one PHP file has one class.
- To be compatible with future PHPUnit versions, we should let the all test classes use the class-based PHPUnit namespace.
- According to the Travis blog post, the default dist is `Xenial`.
But the `php-5.4` and `php-5.5` are only available on `Trusty`.
To be done for these PHP version tests, add them inside `matrix` setting and set the `trusty` dist.

And the completed Travis CI build log is available [here](https://travis-ci.org/gburtini/Probability-Distributions-for-PHP/builds/577222453).