### PR TITLE
Add autoloader script when not insatlling via composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ All supported distributions are in the namespace `gburtini\Distributions` and im
 Examples are provided in a comment at the top of most of the implementation files. In general, you should be able to use the parametrization listed above under "Supported Distributions" to create classes that implement the methods under "Interfaces".
 
 ```php
-// If you don't want to manually include all files then you can use this autolader from https://stackoverflow.com/a/6962046
+// If you don't want to manually include all files then you can use this autolader from
+// https://stackoverflow.com/a/6962046
 spl_autoload_register(
     function($className)
     {

--- a/README.md
+++ b/README.md
@@ -48,6 +48,26 @@ All supported distributions are in the namespace `gburtini\Distributions` and im
 Examples are provided in a comment at the top of most of the implementation files. In general, you should be able to use the parametrization listed above under "Supported Distributions" to create classes that implement the methods under "Interfaces".
 
 ```php
+// If you don't want to manually include all files then you can use this autolader from https://stackoverflow.com/a/6962046
+spl_autoload_register(
+    function($className)
+    {
+        $className = str_replace("_", "\\", $className);
+        $className = ltrim($className, '\\');
+        $fileName = '';
+        $namespace = '';
+        if ($lastNsPos = strripos($className, '\\'))
+        {
+            $namespace = substr($className, 0, $lastNsPos);
+            $className = substr($className, $lastNsPos + 1);
+            $fileName = str_replace('\\', DIRECTORY_SEPARATOR, $namespace) . DIRECTORY_SEPARATOR;
+        }
+        $fileName .= str_replace('_', DIRECTORY_SEPARATOR, $className) . '.php';
+
+        require $fileName;
+    }
+);
+
 use gburtini\Distributions\Beta;
 $beta = new Beta(1, 100);
 $draw = $beta->rand();


### PR DESCRIPTION
When using this repo without installing it via composer it is not enough to just download all files. You also have to include then manually. Thankfully someone on Stackoverflow (https://stackoverflow.com/a/6962046) has written an autoloader to automatically include all files. Since it worked for me flawlessly I think mentioning this is a good idea.